### PR TITLE
sickbeard.sh:  Make sure we set ownership on the config file

### DIFF
--- a/sickbeard.sh
+++ b/sickbeard.sh
@@ -32,6 +32,7 @@ echo "[DONE]"
 
 printf "Set permissions... "
 touch ${CONFIG}
+chown "${USER}:${USER}" "${CONFIG}"
 chown -R ${USER}: /sickbeard
 chown ${USER}: /datadir /media $(dirname ${CONFIG})
 echo "[DONE]"


### PR DESCRIPTION
On startup I'm getting an error:

> Config file: /datadir/config.ini must be writeable (write permissions). Exiting.

When the entrypoint touches the config file, it does it as root, not sickbeard.  The result is that sickbeard can't write to it.  This fixes it.